### PR TITLE
Feature disable route status update

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -23,11 +23,17 @@
     <a href="http://plugins.jetbrains.com/plugin/7110">plugin page</a>.
     ]]></description>
 
-    <version>0.8.2</version>
+    <version>0.8.3-beta</version>
     <vendor email="bas.gren@gmail.com">Basil Gren</vendor>
 
 
     <change-notes><![CDATA[
+
+        <p><b>0.8.3-beta</b><br/>
+        <ul>
+            <li>Optimize performance of route action availability check.</li>
+            <li>Add option to disable live check of route action implementation.</li>
+        </ul></p>
 
         <p><b>0.8.2</b><br/>
         <ul>

--- a/src/net/bitpot/railways/gui/RailwaysSettingsForm.form
+++ b/src/net/bitpot/railways/gui/RailwaysSettingsForm.form
@@ -8,11 +8,13 @@
     <rowspec value="center:max(p;4px):noGrow"/>
     <rowspec value="top:4dlu:noGrow"/>
     <rowspec value="center:d:grow"/>
+    <rowspec value="top:4dlu:noGrow"/>
+    <rowspec value="center:d:grow"/>
     <colspec value="fill:p:noGrow"/>
     <colspec value="left:4dlu:noGrow"/>
     <colspec value="fill:d:grow"/>
     <constraints>
-      <xy x="20" y="20" width="450" height="124"/>
+      <xy x="20" y="20" width="450" height="152"/>
     </constraints>
     <properties>
       <minimumSize width="450" height="120"/>
@@ -70,9 +72,18 @@
           <text value="Auto update route list on routes.rb change"/>
         </properties>
       </component>
+      <component id="a8cde" class="javax.swing.JCheckBox" binding="liveActionHighlightingChk">
+        <constraints>
+          <grid row="6" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <forms/>
+        </constraints>
+        <properties>
+          <text value="Enable live highlighting of found controller actions"/>
+        </properties>
+      </component>
       <vspacer id="364d2">
         <constraints>
-          <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
           <forms defaultalign-vert="false"/>
         </constraints>
       </vspacer>

--- a/src/net/bitpot/railways/gui/RailwaysSettingsForm.form
+++ b/src/net/bitpot/railways/gui/RailwaysSettingsForm.form
@@ -7,18 +7,18 @@
     <rowspec value="top:4dlu:noGrow"/>
     <rowspec value="center:max(p;4px):noGrow"/>
     <rowspec value="top:4dlu:noGrow"/>
-    <rowspec value="center:d:grow"/>
+    <rowspec value="center:p:grow"/>
     <rowspec value="top:4dlu:noGrow"/>
     <rowspec value="center:d:grow"/>
     <colspec value="fill:p:noGrow"/>
     <colspec value="left:4dlu:noGrow"/>
     <colspec value="fill:d:grow"/>
     <constraints>
-      <xy x="20" y="20" width="450" height="152"/>
+      <xy x="20" y="20" width="450" height="164"/>
     </constraints>
     <properties>
       <minimumSize width="450" height="120"/>
-      <preferredSize width="450" height="120"/>
+      <preferredSize width="450" height="130"/>
     </properties>
     <border type="none"/>
     <children>
@@ -78,7 +78,7 @@
           <forms/>
         </constraints>
         <properties>
-          <text value="Enable live highlighting of found controller actions"/>
+          <text value="Enable live check of route actions availability"/>
         </properties>
       </component>
       <vspacer id="364d2">

--- a/src/net/bitpot/railways/gui/RailwaysSettingsForm.java
+++ b/src/net/bitpot/railways/gui/RailwaysSettingsForm.java
@@ -28,6 +28,7 @@ public class RailwaysSettingsForm {
     private LanguageTextField routesTaskEdit;
     private JComboBox environmentCombo;
     private JCheckBox autoUpdateChk;
+    private JCheckBox liveActionHighlightingChk;
 
     private final Module myModule;
 
@@ -101,6 +102,7 @@ public class RailwaysSettingsForm {
         routesTaskEdit.setText(settings.routesTaskName);
         initRailsEnvsComboBox(settings.environment, environmentCombo, myModule);
         autoUpdateChk.setSelected(settings.autoUpdate);
+        liveActionHighlightingChk.setSelected(settings.liveActionHighlighting);
     }
 
 
@@ -114,6 +116,7 @@ public class RailwaysSettingsForm {
         settings.environment = environmentCombo.getSelectedIndex() == 0 ? null :
                 (String)(environmentCombo.getSelectedItem());
         settings.autoUpdate = autoUpdateChk.isSelected();
+        settings.liveActionHighlighting = liveActionHighlightingChk.isSelected();
     }
 
 

--- a/src/net/bitpot/railways/models/RailsActionInfo.java
+++ b/src/net/bitpot/railways/models/RailsActionInfo.java
@@ -65,21 +65,37 @@ public class RailsActionInfo {
     }
 
     // TODO: cache found classes and methods to reuse found values.
-
     public void update(RailsApp app, String controllerShortName, String actionName) {
-        psiMethod = null;
-        psiClass = null;
-
-        if ((app == null) || controllerShortName.isEmpty())
+        if ((app == null) || controllerShortName.isEmpty()) {
+            psiMethod = null;
+            psiClass = null;
             return;
+        }
 
-        String qualifiedName = RailwaysPsiUtils.getControllerClassNameByShortName(
-                controllerShortName);
-        psiClass = RailwaysPsiUtils.findControllerClass(app, qualifiedName);
+        if (psiClass != null && !psiClass.isValid()) {
+            psiMethod = null;
+            psiClass = null;
+        }
 
-        if (psiClass != null)
-            psiMethod = RailwaysPsiUtils.findControllerMethod(app,
-                    psiClass, actionName);
+        // Find psiClass if it's not specified or already invalid.
+        if (psiClass == null) {
+            String qualifiedName = RailwaysPsiUtils.getControllerClassNameByShortName(
+                    controllerShortName);
+            psiClass = RailwaysPsiUtils.findControllerClass(app, qualifiedName);
+        }
+
+        if (psiClass != null) {
+            if (psiMethod == null || !psiMethod.isValid()) {
+                psiMethod = RailwaysPsiUtils.findControllerMethod(app,
+                        psiClass, actionName);
+            } else {
+                // Even if psiMethod is valid, its name can be different - it
+                // usually happens when user edits method name - the psiElement
+                // is just updated.
+                if (!psiMethod.getName().equals(actionName))
+                    psiMethod = null;
+            }
+        }
     }
 
 }

--- a/src/net/bitpot/railways/routesView/RoutesManager.java
+++ b/src/net/bitpot/railways/routesView/RoutesManager.java
@@ -87,6 +87,10 @@ public class RoutesManager implements PersistentStateComponent<RoutesManager.Sta
 
         // Automatically update routes when routes.rb file is changed.
         public Boolean autoUpdate = false;
+
+        // Check whether route action is found in the project and highlight
+        // actions in route list depending on their availability.
+        public boolean liveActionHighlighting = true;
     }
 
 

--- a/src/net/bitpot/railways/routesView/RoutesView.java
+++ b/src/net/bitpot/railways/routesView/RoutesView.java
@@ -324,8 +324,9 @@ public class RoutesView implements PersistentStateComponent<RoutesView.State>,
     }
 
     private void refreshRouteActionsStatus() {
-        RouteList routes = currentPane.getRoutesManager().getRouteList();
-        if (routes.size() == 0 || !isLiveHighlightingEnabled())
+        RoutesManager rm = currentPane.getRoutesManager();
+        RouteList routes = rm.getRouteList();
+        if (rm.isUpdating() || routes.size() == 0 || !isLiveHighlightingEnabled())
             return;
 
         RailwaysUtils.updateActionsStatus(currentPane.getModule(), routes);
@@ -348,7 +349,7 @@ public class RoutesView implements PersistentStateComponent<RoutesView.State>,
                 public void run() {
                     refreshRouteActionsStatus();
                 }
-            }, 300, ModalityState.NON_MODAL);
+            }, 1000, ModalityState.NON_MODAL);
         }
     }
 

--- a/src/net/bitpot/railways/routesView/RoutesView.java
+++ b/src/net/bitpot/railways/routesView/RoutesView.java
@@ -319,10 +319,13 @@ public class RoutesView implements PersistentStateComponent<RoutesView.State>,
         }
     }
 
+    private boolean isLiveHighlightingEnabled() {
+        return currentPane.getRoutesManager().getState().liveActionHighlighting;
+    }
 
     private void refreshRouteActionsStatus() {
         RouteList routes = currentPane.getRoutesManager().getRouteList();
-        if (routes.size() == 0)
+        if (routes.size() == 0 || !isLiveHighlightingEnabled())
             return;
 
         RailwaysUtils.updateActionsStatus(currentPane.getModule(), routes);
@@ -335,7 +338,8 @@ public class RoutesView implements PersistentStateComponent<RoutesView.State>,
 
         @Override
         public void modificationCountChanged() {
-            if (PowerSaveMode.isEnabled() || !myToolWindow.isVisible())
+            if (PowerSaveMode.isEnabled() || !myToolWindow.isVisible() ||
+                    !isLiveHighlightingEnabled())
                 return;
 
             alarm.cancelAllRequests();


### PR DESCRIPTION
Added option to disable live route actions availability check.
Optimized performance of route actions availability check. This is noticeable in applications with huge number of routes (1000+).