### PR TITLE
Updating Utils to use rails instead of rake, which was deprecated in 6.1

### DIFF
--- a/src/net/bitpot/railways/utils/RailwaysUtils.java
+++ b/src/net/bitpot/railways/utils/RailwaysUtils.java
@@ -81,7 +81,7 @@ public class RailwaysUtils {
             railsEnv = (railsEnv == null) ? "" : "RAILS_ENV=" + railsEnv;
 
             // Will work on IntelliJ platform since 2017.3
-            return RubyGemExecutionContext.create(sdk, "rake")
+            return RubyGemExecutionContext.create(sdk, "rails")
                     .withModule(module)
                     .withWorkingDirPath(moduleContentRoot)
                     .withExecutionMode(new ExecutionModes.SameThreadMode())


### PR DESCRIPTION
Fix for https://github.com/basgren/railways/issues/48